### PR TITLE
Fix content scripts matches

### DIFF
--- a/extension/app/manifest.json
+++ b/extension/app/manifest.json
@@ -19,8 +19,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://docs.google.com/spreadsheets/d/*",
-        "https://drive.google.com/drive/u/*/folders/*"
+        "https://docs.google.com/spreadsheets/*",
+        "https://drive.google.com/drive/*"
       ],
       "js": ["js/jquery-3.5.0.min.js", "js/contents.js"]
     }


### PR DESCRIPTION
Fix an error with URLs like `https://drive.google.com/drive/folders/*` not matching.