### PR TITLE
Fix decode in GAS

### DIFF
--- a/gas/apply.gs
+++ b/gas/apply.gs
@@ -16,7 +16,11 @@ function doPost(e) {
     overlaySheetNames,
     rootFolderId,
     applyPassword,
-  } = JSON.parse(decodeURI(e.postData.getDataAsString()));
+  } = JSON.parse(
+    decodeURI(
+      e.postData.getDataAsString().replace(/%(?![0-9][0-9a-fA-F]+)/g, "%25")
+    )
+  );
   const response = {};
 
   if (applyPassword !== password) {

--- a/gas/sync.gs
+++ b/gas/sync.gs
@@ -16,7 +16,11 @@ function doPost(e) {
     rootFolderId,
     spreadsheetPath,
     syncPassword,
-  } = JSON.parse(decodeURI(e.postData.getDataAsString()));
+  } = JSON.parse(
+    decodeURI(
+      e.postData.getDataAsString().replace(/%(?![0-9][0-9a-fA-F]+)/g, "%25")
+    )
+  );
   const response = {};
 
   if (syncPassword !== password) {


### PR DESCRIPTION
Fix an error `URIError: URI malformed` and decoding failed if the string contains "%".

https://stackoverflow.com/questions/7449588/why-does-decodeuricomponent-lock-up-my-browser