### PR TITLE
Fix sync api error

### DIFF
--- a/cli/ssbird/cmd/sync.go
+++ b/cli/ssbird/cmd/sync.go
@@ -107,9 +107,12 @@ func sync() error {
 	if err != nil {
 		return err
 	}
-	_, err = request("POST", viper.GetString("syncUrl"), googleAccessToken, syncRequestJson)
+	syncResponse, err := request("POST", viper.GetString("syncUrl"), googleAccessToken, syncRequestJson)
 	if err != nil {
 		return err
+	}
+	if syncResponse != "{}" {
+		return fmt.Errorf("Error Response")
 	}
 
 	return nil


### PR DESCRIPTION
Exit with an error if sync api returns an unexpected response.